### PR TITLE
Rename CWD to ~/.docker-osx

### DIFF
--- a/docker
+++ b/docker
@@ -20,7 +20,7 @@
 
 set -e
 
-export VAGRANT_CWD="$HOME/.docker"
+export VAGRANT_CWD="$HOME/.docker-osx"
 export FORWARD_DOCKER_PORTS="yes"
 
 export DOCKER_VERSION="0.7.2"


### PR DESCRIPTION
It seems likely that Docker may use ~/.docker in the future, and we do not want to collide with them.

This is also quite a neat upgrade path from compiled Docker to pre-built binaries, because everything will be put in a new directory.

@noplay – what do you think?
