### PR TITLE
Mount home directory on VM

### DIFF
--- a/docker
+++ b/docker
@@ -60,6 +60,7 @@ Vagrant.configure("2") do |config|
   config.vm.network :forwarded_port, guest: 4243, host: 4243
   config.vm.provision :shell, :inline => "apt-get update; apt-get install -y lxc-docker=$DOCKER_VERSION"
   config.vm.provision :shell, :inline => "echo 'export DOCKER_OPTS=\"-H unix:///var/run/docker.sock -H tcp://0.0.0.0:4243\"' >> /etc/default/docker"
+  config.vm.synced_folder "$(echo ~)", "$(echo ~)", :create => true
 
   config.vm.provider :virtualbox do |vb|
     vb.customize ['modifyvm', :id, '--memory', ENV['VM_MEMORY'] || 1024]


### PR DESCRIPTION
It is mounted at /Users/username on the VM so using volumes within
your home directory more-or-less works seamlessly.

E.g. you could use this to mount some code you're working on inside
a container:

$ docker run -v `pwd`:/opt myimage python app.py
