### PR TITLE
Give Vagrant VM a static IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Docker on OS X in three steps:
 
 This script acts as both an installer and a Docker binary. On first run, it installs an OS X binary of the Docker client and starts a virtual machine with the Docker daemon running. It then passes through all invocations of `docker` to the client which controls the daemon running on the virtual machine.
 
+The virtual machine that Docker runs on is given the hostname `localdocker`. For example, if you run `docker run -p 8000:8000 ...`, then that will be available at `localdocker:8000` from OS X.
+
 ## Additional commands
 
 Two extra commands have been added to `docker` as shortcuts for controlling the Vagrant VM:

--- a/docker
+++ b/docker
@@ -57,8 +57,8 @@ Vagrant.configure("2") do |config|
   config.vm.box_url = "$VAGRANT_BOX_URL"
 
   config.ssh.forward_agent = true
-  config.vm.network :forwarded_port, :guest => 4243, :host => 4243
-
+  config.vm.network "forwarded_port", :guest => 4243, :host => 4243
+  config.vm.network "private_network", :ip => "172.16.42.43"
   config.vm.provision :shell, :inline => "apt-get update; apt-get install -y lxc-docker=$DOCKER_VERSION"
   config.vm.provision :shell, :inline => "echo 'export DOCKER_OPTS=\"-H unix:///var/run/docker.sock -H tcp://0.0.0.0:4243\"' >> /etc/default/docker"
   config.vm.synced_folder "$(echo ~)", "$(echo ~)", :create => true
@@ -73,6 +73,12 @@ Vagrant.configure("2") do |config|
   eval File.open(vagrantfile_extra).read if File.exists?(vagrantfile_extra)
 end
 EOL
+
+if ! grep -q localdocker /etc/hosts
+then
+  echo "Adding localdocker to /etc/hosts (may need your password for sudo)..."
+  sudo sh -c "echo '172.16.42.43 localdocker' >> /etc/hosts"
+fi
 
 # Download Docker client if it doesn't exist or needs updating
 if [[ ! -f "$DOCKER_BIN" || $INSTALLED_DOCKER_VERSION != $DOCKER_VERSION ]]


### PR DESCRIPTION
This sort of sucks, because we can't guarantee that 10.10.10.10 (or whatever) won't clobber something on your local network, but I'm not sure what a better solution is.

Ideally we'd also use something like this to set up a `docker` hostname or similar: 

https://github.com/smdahlen/vagrant-hostmanager

Unfortunately installing Vagrant plugins is slow, which makes this complicated. I'll open a new issue about that.
