### PR TITLE
extra config injected from ~/.docker-osx/Vagrantfile.extra_config

### DIFF
--- a/docker
+++ b/docker
@@ -58,12 +58,10 @@ Vagrant.configure("2") do |config|
 
   config.ssh.forward_agent = true
   config.vm.network :forwarded_port, :guest => 4243, :host => 4243
-EOL
-if [ -f $VAGRANT_CWD/Vagrantfile.extra_config ]
-then
-  cat $VAGRANT_CWD/Vagrantfile.extra_config >> "$VAGRANT_CWD/Vagrantfile"
-fi
-cat >> "$VAGRANT_CWD/Vagrantfile" <<EOL
+
+  vagrantfile_extra = "#{ENV['VAGRANT_CWD']}/Vagrantfile_extra.rb"
+  eval File.open(vagrantfile_extra).read if File.exists?(vagrantfile_extra)
+
   config.vm.provision :shell, :inline => "apt-get update; apt-get install -y lxc-docker=$DOCKER_VERSION"
   config.vm.provision :shell, :inline => "echo 'export DOCKER_OPTS=\"-H unix:///var/run/docker.sock -H tcp://0.0.0.0:4243\"' >> /etc/default/docker"
   config.vm.synced_folder "$(echo ~)", "$(echo ~)", :create => true


### PR DESCRIPTION
Adding a file name `Vagrantfile_extra.rb` into the `~/.docker-osx` directory will allow to keep some additional config for Vagrant without messing up too much the installation.

I used it for port forwarding some extra ports.

My `Vagrantfile_extra.rb` looks like:

```
config.vm.network :forwarded_port, guest: 3000, host: 3000
config.vm.network :forwarded_port, guest: 8080, host: 8080
```

This dirty patch doesn't want to be a final solution, just an idea to open the discussion about extend and customisation methods.
