### PR TITLE
drop port forwarding and give names to magic variables

### DIFF
--- a/docker
+++ b/docker
@@ -22,13 +22,15 @@ set -e
 
 export VAGRANT_CWD="$HOME/.docker-osx"
 export FORWARD_DOCKER_PORTS="yes"
+export DOCKER_IP="172.16.42.43"
+export DOCKER_HOST="localdocker"
 
 export DOCKER_VERSION="0.7.2"
 export DOCKER_CLIENT_URL="http://static.orchardup.com/binaries/docker/docker-darwin-amd64-0.7.2-dev"
 export VAGRANT_BOX_URL="http://static.orchardup.com/binaries/vagrant/vagrant-docker-0.7.2-virtualbox.box"
 
 DOCKER_BIN="$VAGRANT_CWD/bin/docker"
-DOCKER_CMD="$DOCKER_BIN -H=tcp://127.0.0.1:4243"
+DOCKER_CMD="$DOCKER_BIN -H=tcp://$DOCKER_IP:4243"
 
 # Determine currently installed version of Docker
 INSTALLED_DOCKER_VERSION=""
@@ -58,8 +60,7 @@ Vagrant.configure("2") do |config|
   config.vm.box_url = "$VAGRANT_BOX_URL"
 
   config.ssh.forward_agent = true
-  config.vm.network "forwarded_port", :guest => 4243, :host => 4243
-  config.vm.network "private_network", :ip => "172.16.42.43"
+  config.vm.network "private_network", :ip => "$DOCKER_IP"
   config.vm.provision :shell, :inline => "apt-get update; apt-get install -y lxc-docker=$DOCKER_VERSION"
   config.vm.provision :shell, :inline => "echo 'export DOCKER_OPTS=\"-H unix:///var/run/docker.sock -H tcp://0.0.0.0:4243\"' >> /etc/default/docker"
   config.vm.synced_folder "$(echo ~)", "$(echo ~)", :create => true
@@ -75,10 +76,10 @@ Vagrant.configure("2") do |config|
 end
 EOL
 
-if ! grep -q localdocker /etc/hosts
+if ! grep -q $DOCKER_HOST /etc/hosts
 then
-  echo "Adding localdocker to /etc/hosts (may need your password for sudo)..."
-  sudo sh -c "echo '172.16.42.43 localdocker' >> /etc/hosts"
+  echo "Adding $DOCKER_HOST to /etc/hosts (may need your password for sudo)..."
+  sudo sh -c "echo '$DOCKER_IP $DOCKER_HOST' >> /etc/hosts"
 fi
 
 # Download Docker client if it doesn't exist or needs updating


### PR DESCRIPTION
I'm not great with bash scripting so I opted to avoid trying to merge environment vars into the config, but at least they have explicit names for anyone copying the file.
