### PR TITLE
Version '0.7.3' for 'lxc-docker' was not found

### DIFF
--- a/docker-osx
+++ b/docker-osx
@@ -124,7 +124,7 @@ Vagrant.configure("2") do |config|
 
   config.ssh.forward_agent = true
   config.vm.network "private_network", :ip => "$DOCKER_IP"
-  config.vm.provision :shell, :inline => "apt-get update; apt-get install -y lxc-docker=$DOCKER_VERSION"
+  config.vm.provision :shell, :inline => "apt-get update; apt-get install -y lxc-docker-$DOCKER_VERSION"
   config.vm.provision :shell, :inline => "echo 'export DOCKER_OPTS=\"-H unix:///var/run/docker.sock -H tcp://0.0.0.0:$DOCKER_PORT\"' >> /etc/default/docker"
   config.vm.synced_folder "$(echo ~)", "$(echo ~)", :create => true
 


### PR DESCRIPTION
I get the error.

Version '0.7.3' for 'lxc-docker' was not found

when I run

```
docker-osx ssh
```

This is because apt-get command should be lxc-docker-$DOCKER_VERSION instead of lxc-docker=$DOCKER_VERSION.
