### PR TITLE
Export DOCKER_HOST environment variable

### DIFF
--- a/docker-osx
+++ b/docker-osx
@@ -39,7 +39,7 @@ then
     . "$DOCKER_DEFAULTS_FILE"
 fi
 
-DOCKER_HOST="tcp://$DOCKER_IP:$DOCKER_PORT"
+export DOCKER_HOST="tcp://$DOCKER_IP:$DOCKER_PORT"
 
 ##########
 function setup_etc_host {


### PR DESCRIPTION
Regression from 1712714cb8c77344d24db594daf38df51bf0dd82.

This has broken installations of https://github.com/orchardup/fig for the past couple of days, so I've updated Fig's installation instructions to use a specific commit of docker-osx.

I think we shouldn't be under the assumption that master is stable. We should probably tag a new release of docker-osx as a known good version, then we can update the readme to point at that known good version so stuff like this won't slip into people actually using docker-osx.
