### PR TITLE
Pass remaining arguments to Vagrant command.

### DIFF
--- a/docker-osx
+++ b/docker-osx
@@ -204,14 +204,17 @@ case "$1" in
     exit 0
     ;;
   destroy)
-    exec vagrant destroy
+    shift
+    exec vagrant destroy "$@"
     ;;
   ssh)
     start_vm
-    exec vagrant ssh
+    shift
+    exec vagrant ssh "$@"
     ;;
   stop|halt)
-    exec vagrant halt
+    shift
+    exec vagrant halt "$@"
     ;;
   help)
     help


### PR DESCRIPTION
This allows:
- Forcing the destroy/halting of the Vagrant box  
  (by running `docker-osx destroy -f` instead of `echo "y" | docker-osx destroy`)
- Providing a command to be run by vagrant ssh  
  (also see http://docs.vagrantup.com/v2/cli/ssh.html)
