### PR TITLE
Always provision on boot

### DIFF
--- a/docker-osx
+++ b/docker-osx
@@ -93,7 +93,7 @@ function start_vm() {
         exit 0
       fi
       echo "Start Docker Virtual machine"
-      vagrant up
+      vagrant up --no-provision
     fi
 
     vagrant provision


### PR DESCRIPTION
Slightly slower to boot an existing VM, but avoids the case where it wouldn't provision a new one if there was a stray `.docker-version` file lying around.
