### PR TITLE
Ensure installation instructions remain current

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Docker on OS X in three steps:
 
 2. Put the `docker-osx` script somewhere on your path:
 
-        curl https://raw.githubusercontent.com/noplay/docker-osx/1.0.0/docker-osx > /usr/local/bin/docker-osx
+        curl https://raw.githubusercontent.com/noplay/docker-osx/HEAD/docker-osx > /usr/local/bin/docker-osx
         chmod +x /usr/local/bin/docker-osx
 
 3. Run:


### PR DESCRIPTION
It could also be set to `1.1.1`, but using HEAD means it won't need to be updated again.
